### PR TITLE
add ec2 placement group support

### DIFF
--- a/c3/aws/ec2/instances.py
+++ b/c3/aws/ec2/instances.py
@@ -171,7 +171,8 @@ class C3Instance(object):
             self.state = self._instance.state
 
     def start(self, ami, sshkey, sgs, user_data, hostname,
-              isize, zone, nodegroups, allocateeips, use_ebsoptimized):
+              isize, zone, nodegroups, allocateeips, use_ebsoptimized,
+              placement_group=None):
         ''' Starts an EC2 instance '''
         # pylint:disable=too-many-arguments
         # Required for boto API
@@ -182,7 +183,8 @@ class C3Instance(object):
         try:
             self._reservation = self.conn.run_instances(
                 ami, 1, 1, sshkey, sgs, user_data, None, isize, zone,
-                None, None, False, None, None, ebs_optimized=use_ebsoptimized)
+                None, None, False, None, None, ebs_optimized=use_ebsoptimized,
+                placement_group=placement_group)
         except EC2ResponseError, msg:
             logging.error(msg.message)
             return None

--- a/c3/utils/config.py
+++ b/c3/utils/config.py
@@ -831,3 +831,7 @@ class ClusterConfig(object):
     def get_rds_config(self):
         ''' Returns dictonary of RDS config items. '''
         return self.rds.get_config()
+
+    def get_placement_group(self):
+        ''' Returns placement group '''
+        return self.get_ini("cluster", "placement_group", str)

--- a/scripts/c3ec2.py
+++ b/scripts/c3ec2.py
@@ -502,7 +502,8 @@ class C3EC2Provision(object):
                         host, self.cconfig.get_size(), used_az,
                         self.cconfig.get_node_groups(),
                         self.cconfig.get_allocate_eips(),
-                        self.cconfig.get_use_ebs_optimized())
+                        self.cconfig.get_use_ebs_optimized(),
+                        self.cconfig.get_placement_group())
                     if instance:
                         success += 1
                         break


### PR DESCRIPTION
If `placement_group` option is specified in cluster settings, the ec2
instances will be launched into that placement group